### PR TITLE
patch for gox in GOPATH/bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ HARDWARE = $(shell uname -m)
 VERSION ?= 0.0.0
 BUILD_TAG ?= dev
 BUILD_DIR ?= build
+PATH := $(GOPATH)/bin:$(PATH)
 
 
 build: build/linux build/darwin build/windows


### PR DESCRIPTION
Modyfing PATH to include gox built by go dependencies in GOPATH/bin.
