### PR TITLE
Introduce compatibility mode - fix #17

### DIFF
--- a/securepass/spctl/compat.go
+++ b/securepass/spctl/compat.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+func handleCompatMode(args []string) []string {
+	dir, basename := filepath.Split(args[0])
+	if strings.HasPrefix(basename, "sp-") {
+		newArgs := strings.Split(basename, "-")
+		newArgs[0] = dir + newArgs[0]
+		// Handle the sp-apps exception, see #17
+		if newArgs[1] == "apps" {
+			newArgs[1] = "app"
+			newArgs = append(newArgs[:2], append([]string{"list"}, newArgs[2:]...)...)
+		}
+		newArgs = append(newArgs, args[1:]...)
+		return newArgs
+	}
+	return args
+}

--- a/securepass/spctl/main.go
+++ b/securepass/spctl/main.go
@@ -31,6 +31,7 @@ func init() {
 }
 
 func main() {
+	args := handleCompatMode(os.Args)
 	a := cli.NewApp()
 	a.Name = "spctl"
 	a.Usage = "manage distributed identities"
@@ -47,5 +48,5 @@ func main() {
 	}
 	a.Commands = cmd.Commands
 
-	a.Run(os.Args)
+	a.Run(args)
 }


### PR DESCRIPTION
When invoked as filename whose name starts with "sp-", spctl enters compatibility mode and emulates the behaviour of the original Python securepass-tools.
